### PR TITLE
Codex/add required name input for new shapes and notes

### DIFF
--- a/ITERATION_LOG.md
+++ b/ITERATION_LOG.md
@@ -11,18 +11,30 @@ Format (template):
 
 ---
 
-## 2025-10-05 — Fix delete behaviors
-- Description: Made the note editor’s delete button remove only the selected note (with confirmation). Restored object deletion via a new "Delete Object" button in the shape edit panel, with its own confirmation.
+## 2025-10-05 — Note editor handles & hover affordance
+- Description: Restyled the note editor resize handles into classic right-angle triangles and added hover/focus feedback to the "+ New Note" button for clearer interactivity cues.
 - Files touched: `index.html`
-- Notes: Modal message now adapts to note vs object deletion.
 
-## 2025-10-05 — Modal overlay z-index + delete confirm
+## 2025-10-05 — Shape editor button layout + close affordance
+- Description: Updated the object edit panel with a top-right close icon, renamed the footer button to “Cancel,” and aligned the trash-can delete button on the left for visual consistency with the note editor.
+- Files touched: `index.html`
 
 ## 2025-10-05 — Close notes when parent object deleted
 - Description: When an object is removed, any open note editor tied to it now closes (or clears state), and pending note openings are cancelled.
 - Files touched: `index.html`
 
+## 2025-10-05 — Modal overlay z-index + delete confirm
+- Description: Ensured the confirmation modal overlays the shape edit panel and that clicking “Yes, Delete” reliably triggers the fade-out and removal.
+- Files touched: `index.html`
+
+## 2025-10-05 — Fix delete behaviors
+- Description: Made the note editor’s delete button remove only the selected note (with confirmation). Restored object deletion via a new "Delete Object" button in the shape edit panel, with its own confirmation.
+- Files touched: `index.html`
+- Notes: Modal message now adapts to note vs object deletion.
+
 ## 2025-10-05 — Add PR template with checklist
+- Description: Added a PR template enforcing iteration log updates, smoke checks, and preservation of the single-file analog sci-fi aesthetic.
+- Files touched: `.github/pull_request_template.md`, `.github/copilot-instructions.md`
 
 ## 2025-10-05 — Tab focus: quick, smooth lock-on
 - Description: Reworked Tab cycle tween to be timestamp-based with an ease-in/out curve, shortened duration, interruptible cycling, and momentum reset for a snappy yet comfortable focus.

--- a/index.html
+++ b/index.html
@@ -205,10 +205,34 @@
             z-index: 3001;
         }
         .modal-buttons { display: flex; justify-content: center; gap: 15px; margin-top: 20px; }
+        .modal-content h3 { margin: 0 0 15px 0; color: #fff; font-weight: 600; }
+        .modal-input {
+            width: 100%;
+            padding: 10px;
+            font-size: 1em;
+            background: rgba(255, 255, 255, 0.1);
+            border: 1px solid rgba(255, 255, 255, 0.5);
+            border-radius: 0;
+            color: #fff;
+            transition: border-color 0.3s, box-shadow 0.3s;
+        }
+        .modal-input:focus {
+            outline: none;
+            border-color: rgba(255, 255, 255, 0.9);
+            box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
+        }
+        .input-error {
+            border-color: rgba(220, 53, 69, 1) !important;
+            box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.4) !important;
+        }
         #modal-confirm-btn { background-color: rgba(220, 53, 69, 0.7); border-color: rgba(220, 53, 69, 1); }
         #modal-confirm-btn:hover { background-color: rgba(200, 48, 62, 0.9); }
         #modal-cancel-btn { background-color: rgba(255, 255, 255, 0.2); border-color: rgba(255,255,255,0.5); }
         #modal-cancel-btn:hover { background-color: rgba(255, 255, 255, 0.4); }
+        #name-prompt-confirm-btn { background-color: rgba(40, 167, 69, 0.7); border-color: rgba(40, 167, 69, 1); }
+        #name-prompt-confirm-btn:hover { background-color: rgba(33, 136, 56, 0.9); }
+        #name-prompt-cancel-btn { background-color: rgba(255, 255, 255, 0.2); border-color: rgba(255,255,255,0.5); }
+        #name-prompt-cancel-btn:hover { background-color: rgba(255, 255, 255, 0.4); }
 
         /* Editor resize affordances */
         .resize-handle {
@@ -432,6 +456,18 @@
         </div>
     </div>
 
+    <!-- Generic name prompt modal for new objects and notes -->
+    <div id="name-prompt-modal" class="modal-overlay" style="display: none;">
+        <div class="modal-content">
+            <h3 id="name-prompt-title">Name Item</h3>
+            <input id="name-prompt-input" class="modal-input" type="text" autocomplete="off">
+            <div class="modal-buttons">
+                <button id="name-prompt-confirm-btn" class="btn">Save</button>
+                <button id="name-prompt-cancel-btn" class="btn">Cancel</button>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/renderers/CSS2DRenderer.js"></script>
@@ -490,7 +526,24 @@
         const dragHandle = document.getElementById('drag-handle');
         const shapeEditPanel = document.getElementById('shape-edit-panel');
         const shapeCloseBtn = document.getElementById('shape-close-btn');
+        const shapeNameInput = document.getElementById('shape-name-input');
+        const shapeTypeSelect = document.getElementById('shape-type-select');
+        const shapeColorInput = document.getElementById('shape-color-input');
+        const namePromptModal = document.getElementById('name-prompt-modal');
+        const namePromptTitle = document.getElementById('name-prompt-title');
+        const namePromptInput = document.getElementById('name-prompt-input');
+        const namePromptConfirmBtn = document.getElementById('name-prompt-confirm-btn');
+        const namePromptCancelBtn = document.getElementById('name-prompt-cancel-btn');
         let deleteAction = null;
+        let activeNamePrompt = null;
+        let wasTypingBeforePrompt = false;
+        let wasTypingBeforeShapeEdit = false;
+
+        shapeNameInput.addEventListener('input', () => {
+            if (shapeNameInput.classList.contains('input-error')) {
+                shapeNameInput.classList.remove('input-error');
+            }
+        });
         
         // =================================================================================
         // SECTION: SETTINGS LOADER (single-file + localStorage overrides)
@@ -631,7 +684,107 @@
                 console.error("Error saving data to localStorage:", e);
             }
         }
-        
+
+        // =================================================================================
+        // SECTION: SHARED NAME ENTRY UTILITIES
+        // =================================================================================
+        /**
+         * Determine the next sequential default name for a given prefix.
+         * @param {string} prefix
+         * @param {string[]} existingNames
+         */
+        function getNextSequentialName(prefix, existingNames = []) {
+            let highest = 0;
+            const pattern = new RegExp(`^${prefix}\\s*(\\d+)$`, 'i');
+            for (const rawName of existingNames) {
+                if (typeof rawName !== 'string') continue;
+                const match = rawName.trim().match(pattern);
+                if (!match) continue;
+                const parsed = parseInt(match[1], 10);
+                if (!Number.isNaN(parsed) && parsed > highest) highest = parsed;
+            }
+            return `${prefix} ${highest + 1}`;
+        }
+
+        /**
+         * Display the shared naming modal, enforcing non-empty submissions.
+         * @param {{
+         *   title?: string,
+         *   defaultValue?: string,
+         *   confirmLabel?: string,
+         *   onConfirm?: (value: string) => void,
+         *   onCancel?: () => void
+         * }} options
+         */
+        function openNamePrompt(options = {}) {
+            const { title = 'Name Item', defaultValue = '', confirmLabel = 'Save', onConfirm, onCancel } = options;
+            activeNamePrompt = { onConfirm, onCancel };
+            namePromptTitle.textContent = title;
+            namePromptInput.value = typeof defaultValue === 'string' ? defaultValue : '';
+            namePromptInput.classList.remove('input-error');
+            namePromptConfirmBtn.textContent = confirmLabel;
+            namePromptModal.style.display = 'flex';
+            wasTypingBeforePrompt = isTyping;
+            isTyping = true;
+            requestAnimationFrame(() => {
+                namePromptInput.focus();
+                namePromptInput.select();
+            });
+        }
+
+        /** Hide and reset the shared naming modal. */
+        function closeNamePrompt() {
+            namePromptModal.style.display = 'none';
+            namePromptInput.value = '';
+            namePromptInput.classList.remove('input-error');
+            namePromptConfirmBtn.textContent = 'Save';
+            const restoreTyping = wasTypingBeforePrompt;
+            wasTypingBeforePrompt = false;
+            isTyping = restoreTyping;
+            activeNamePrompt = null;
+        }
+
+        function handleNamePromptConfirm() {
+            if (!activeNamePrompt) return;
+            const value = namePromptInput.value.trim();
+            if (!value) {
+                namePromptInput.classList.add('input-error');
+                namePromptInput.focus();
+                return;
+            }
+            const { onConfirm } = activeNamePrompt;
+            closeNamePrompt();
+            if (typeof onConfirm === 'function') onConfirm(value);
+        }
+
+        function handleNamePromptCancel() {
+            if (!activeNamePrompt) return;
+            const { onCancel } = activeNamePrompt;
+            closeNamePrompt();
+            if (typeof onCancel === 'function') onCancel();
+        }
+
+        namePromptInput.addEventListener('input', () => {
+            if (namePromptInput.classList.contains('input-error')) {
+                namePromptInput.classList.remove('input-error');
+            }
+        });
+        namePromptConfirmBtn.addEventListener('click', handleNamePromptConfirm);
+        namePromptCancelBtn.addEventListener('click', handleNamePromptCancel);
+        namePromptModal.addEventListener('click', (event) => {
+            if (event.target === namePromptModal) handleNamePromptCancel();
+        });
+        window.addEventListener('keydown', (event) => {
+            if (!activeNamePrompt) return;
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                handleNamePromptConfirm();
+            } else if (event.key === 'Escape') {
+                event.preventDefault();
+                handleNamePromptCancel();
+            }
+        });
+
         /**
          * Rebuild the live 3D scene from persisted data. Safe to call after any mutation.
          * Keeps selections if the object still exists.
@@ -738,7 +891,22 @@
             composer.addPass(filmPass);
 
             // Events: keep concise; prevent Tab from moving focus when cycling objects
-            window.addEventListener('resize', onWindowResize); window.addEventListener('keydown', (event) => { if(event.key === "Tab") { event.preventDefault(); if (!isTyping) cycleToObject(); } else { keyState[event.code] = true; } }); window.addEventListener('keyup', (event) => { keyState[event.code] = false; }); sceneContainer.addEventListener('mousedown', (e) => { sceneContainer.focus(); }); sceneContainer.addEventListener('click', onObjectClick);
+            window.addEventListener('resize', onWindowResize);
+            window.addEventListener('keydown', (event) => {
+                if (activeNamePrompt) {
+                    if (event.key === 'Tab') event.preventDefault();
+                    return;
+                }
+                if (event.key === 'Tab') {
+                    event.preventDefault();
+                    if (!isTyping) cycleToObject();
+                } else {
+                    keyState[event.code] = true;
+                }
+            });
+            window.addEventListener('keyup', (event) => { keyState[event.code] = false; });
+            sceneContainer.addEventListener('mousedown', (e) => { sceneContainer.focus(); });
+            sceneContainer.addEventListener('click', onObjectClick);
 
             // Accessibility: disable nav while typing
             noteTitleInput.addEventListener('focus', () => { isTyping = true; }); noteTitleInput.addEventListener('blur', () => { isTyping = false; }); noteContentInput.addEventListener('focus', () => { isTyping = true; }); noteContentInput.addEventListener('blur', () => { isTyping = false; });
@@ -750,10 +918,9 @@
             closeBtn.addEventListener('click', closeNoteEditorWithAnimation);
             modalConfirmBtn.addEventListener('click', () => { if (deleteAction) deleteAction(); });
             modalCancelBtn.addEventListener('click', hideModal);
-            const closeShapeEdit = () => { shapeEditPanel.style.display = 'none'; editingObject = null; };
             document.getElementById('save-shape-btn').addEventListener('click', saveShapeChanges);
-            document.getElementById('close-shape-edit-btn').addEventListener('click', closeShapeEdit);
-            shapeCloseBtn.addEventListener('click', closeShapeEdit);
+            document.getElementById('close-shape-edit-btn').addEventListener('click', closeShapeEditPanel);
+            shapeCloseBtn.addEventListener('click', closeShapeEditPanel);
             document.getElementById('delete-shape-btn').addEventListener('click', handleDeleteObjectFromShapeEditor);
 
             // Draggable + resizable editor
@@ -772,7 +939,7 @@
         function initResizeBR(element, handle) { let startX, startY, startWidth, startHeight; function doDrag(e) { e.preventDefault(); element.style.width = (startWidth + (e.clientX - startX)) + 'px'; element.style.height = (startHeight + (e.clientY - startY)) + 'px'; } function stopDrag() { document.documentElement.removeEventListener('mousemove', doDrag, false); document.documentElement.removeEventListener('mouseup', stopDrag, false); } handle.addEventListener('mousedown', (e) => { e.preventDefault(); e.stopPropagation(); startX = e.clientX; startY = e.clientY; const rect = element.getBoundingClientRect(); startWidth = rect.width; startHeight = rect.height; element.style.left = rect.left + 'px'; element.style.right = 'auto'; document.documentElement.addEventListener('mousemove', doDrag, false); document.documentElement.addEventListener('mouseup', stopDrag, false); }, false); }
         
         /** Open shape editor for new object creation. */
-        function handleAddNewObjectClick() { editingObject = null; showShapeEditPanel(); }
+        function handleAddNewObjectClick() { showShapeEditPanel(); }
         
         /**
          * Save the active note's content. Sets or clears a "sticky note" decal if notes exist.
@@ -784,7 +951,46 @@
         function closeNoteEditorWithAnimation() { uiContainer.classList.add('closing'); uiContainer.addEventListener('animationend', () => { uiContainer.style.display = 'none'; uiContainer.classList.remove('closing'); activeNote = { object: null, index: -1 }; lastIntersection = null; }, { once: true }); }
         
         /** Save object property edits or create a new object. */
-        function saveShapeChanges() { const newName = document.getElementById('shape-name-input').value; const newShape = document.getElementById('shape-type-select').value; const newColor = document.getElementById('shape-color-input').value; if (editingObject) { const objectId = editingObject.userData.id; const objectData = sceneData.get(objectId); if (objectData) { objectData.name = newName; objectData.shape = newShape; objectData.color = newColor; sceneData.set(objectId, objectData); } } else { const newId = crypto.randomUUID(); sceneData.set(newId, { name: newName, shape: newShape, color: newColor, position: { x: (Math.random() - 0.5) * 20, y: Math.random() * 2 + 1, z: (Math.random() - 0.5) * 20 }, notes: [], decal: null }); } saveDataToStorage(); rebuildSceneFromData(); shapeEditPanel.style.display = 'none'; editingObject = null; }
+        function saveShapeChanges() {
+            const newName = shapeNameInput.value.trim();
+            if (!newName) {
+                shapeNameInput.classList.add('input-error');
+                shapeNameInput.focus();
+                return;
+            }
+
+            const newShape = shapeTypeSelect.value;
+            const newColor = shapeColorInput.value;
+
+            if (editingObject) {
+                const objectId = editingObject.userData.id;
+                const objectData = sceneData.get(objectId);
+                if (objectData) {
+                    objectData.name = newName;
+                    objectData.shape = newShape;
+                    objectData.color = newColor;
+                    sceneData.set(objectId, objectData);
+                }
+            } else {
+                const newId = crypto.randomUUID();
+                sceneData.set(newId, {
+                    name: newName,
+                    shape: newShape,
+                    color: newColor,
+                    position: {
+                        x: (Math.random() - 0.5) * 20,
+                        y: Math.random() * 2 + 1,
+                        z: (Math.random() - 0.5) * 20,
+                    },
+                    notes: [],
+                    decal: null,
+                });
+            }
+
+            saveDataToStorage();
+            rebuildSceneFromData();
+            closeShapeEditPanel();
+        }
         
         /** Confirm delete object flow from shape editor. */
         function handleDeleteObjectFromShapeEditor() {
@@ -794,8 +1000,7 @@
             deleteAction = () => {
                 fadeAndDeleteObject(editingObject);
                 hideModal();
-                shapeEditPanel.style.display = 'none';
-                editingObject = null;
+                closeShapeEditPanel();
                 if (activeObjectUI) activeObjectUI.element.style.display = 'none';
                 activeObjectUI = null;
             };
@@ -877,32 +1082,66 @@
         /** Construct a THREE.Mesh from ObjectData and attach an on-object UI label. */
         function createObjectFromData(data, id) { const geometry = getGeometry(data.shape); const material = new THREE.MeshStandardMaterial({ color: data.color || "#ffffff", roughness: 0.5, metalness: 0.1 }); const mesh = new THREE.Mesh(geometry, material); mesh.position.set(data.position.x, data.position.y, data.position.z); mesh.castShadow = true; mesh.receiveShadow = true; mesh.userData = { id, data }; const objectDiv = document.createElement('div'); objectDiv.className = 'object-ui'; const header = document.createElement('div'); header.className = 'object-ui-header'; const title = document.createElement('h3'); title.textContent = data.name; const editBtn = document.createElement('button'); editBtn.className = 'edit-shape-btn'; editBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M12.854.146a.5.5 0 0 0-.707 0L10.5 1.793 14.207 5.5l1.647-1.646a.5.5 0 0 0 0-.708l-3-3zm.646 6.061L9.793 2.5 3.293 9H3.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.207l6.5-6.5zm-7.468 7.468A.5.5 0 0 1 6 13.5V13h-.5a.5.5 0 0 1-.5-.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.5-.5V10h-.5a.499.499 0 0 1-.175-.032l-.179.178a.5.5 0 0 0-.11.168l-2 5a.5.5 0 0 0 .65.65l5-2a.5.5 0 0 0 .168-.11l.178-.178z"/></svg>`; editBtn.onclick = (e) => { e.stopPropagation(); showShapeEditPanel(mesh); }; header.appendChild(title); header.appendChild(editBtn); const notesList = document.createElement('ul'); notesList.className = 'notes-list'; (data.notes || []).forEach((note, index) => { const li = document.createElement('li'); li.textContent = note.title || `Note ${index + 1}`; li.onclick = (e) => { e.stopPropagation(); openNoteEditor(mesh, index); }; notesList.appendChild(li); }); const addNoteBtn = document.createElement('button'); addNoteBtn.className = 'add-note-btn'; addNoteBtn.textContent = '+ New Note'; addNoteBtn.onclick = (e) => { e.stopPropagation(); addNewNote(mesh); }; objectDiv.appendChild(header); objectDiv.appendChild(notesList); objectDiv.appendChild(addNoteBtn); const objectLabel = new THREE.CSS2DObject(objectDiv); objectLabel.position.set(0, 1.5, 0); mesh.add(objectLabel); mesh.label = objectLabel; objectLabel.element.style.display = 'none'; scene.add(mesh); objects.set(id, mesh); placeOrUpdateDecal(id, data); }
         /** Populate and show the shape edit panel (or defaults for a new object). */
-        function showShapeEditPanel(object = null) { editingObject = object; if (editingObject) { const data = editingObject.userData.data; document.getElementById('shape-name-input').value = data.name; document.getElementById('shape-type-select').value = data.shape; document.getElementById('shape-color-input').value = data.color; } else { document.getElementById('shape-name-input').value = "New Shape"; document.getElementById('shape-type-select').value = "Box"; document.getElementById('shape-color-input').value = "#" + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0'); } shapeEditPanel.style.display = 'flex'; }
+        function showShapeEditPanel(object = null) {
+            editingObject = object;
+            shapeNameInput.classList.remove('input-error');
+
+            if (editingObject) {
+                const data = editingObject.userData.data;
+                shapeNameInput.value = data.name;
+                shapeTypeSelect.value = data.shape;
+                shapeColorInput.value = data.color;
+            } else {
+                const existingNames = Array.from(sceneData.values()).map(entry => (entry && entry.name) ? entry.name : '');
+                shapeNameInput.value = getNextSequentialName('Shape', existingNames);
+                shapeTypeSelect.value = 'Box';
+                shapeColorInput.value = '#' + Math.floor(Math.random() * 16777215).toString(16).padStart(6, '0');
+            }
+
+            shapeEditPanel.style.display = 'flex';
+            wasTypingBeforeShapeEdit = isTyping;
+            isTyping = true;
+
+            requestAnimationFrame(() => {
+                shapeNameInput.focus();
+                if (!editingObject) {
+                    shapeNameInput.select();
+                }
+            });
+        }
+
+        /** Hide the shape edit panel and reset state. */
+        function closeShapeEditPanel() {
+            shapeEditPanel.style.display = 'none';
+            editingObject = null;
+            shapeNameInput.classList.remove('input-error');
+            isTyping = wasTypingBeforeShapeEdit;
+            wasTypingBeforeShapeEdit = false;
+        }
         
         /** Create and select a new empty note for an object, auto-numbered. */
         function addNewNote(object) {
             const objectId = object.userData.id;
             const objectData = sceneData.get(objectId);
             if (!objectData) return;
-            const notes = objectData.notes || [];
-            let highestNoteNumber = 0;
-            notes.forEach(note => {
-                if (note.title && note.title.startsWith('Note ')) {
-                    const numberPart = note.title.substring(5);
-                    const noteNumber = parseInt(numberPart, 10);
-                    if (!isNaN(noteNumber) && noteNumber > highestNoteNumber) {
-                        highestNoteNumber = noteNumber;
-                    }
-                }
+
+            const notes = Array.isArray(objectData.notes) ? [...objectData.notes] : [];
+            const existingNames = notes.map(note => (note && note.title) ? note.title : '');
+            const suggestedTitle = getNextSequentialName('Note', existingNames);
+
+            openNamePrompt({
+                title: 'Name your note',
+                defaultValue: suggestedTitle,
+                confirmLabel: 'Create Note',
+                onConfirm: (noteTitle) => {
+                    const updatedNotes = [...notes, { title: noteTitle, content: '' }];
+                    objectData.notes = updatedNotes;
+                    sceneData.set(objectId, objectData);
+                    saveDataToStorage();
+                    rebuildSceneFromData();
+                    pendingNoteOpen = { objectId, noteIndex: updatedNotes.length - 1 };
+                },
             });
-            const newNoteTitle = `Note ${highestNoteNumber + 1}`;
-            const newNoteIndex = notes.length;
-            notes.push({title: newNoteTitle, content: ''});
-            objectData.notes = notes;
-            sceneData.set(objectId, objectData);
-            saveDataToStorage();
-            rebuildSceneFromData();
-            pendingNoteOpen = { objectId, noteIndex: newNoteIndex };
         }
 
         /** Open the main note editor populated with the selected note. */

--- a/index.html
+++ b/index.html
@@ -160,6 +160,8 @@
             background-color: rgba(200, 48, 62, 0.9);
         }
         #delete-note svg { width: 1.2em; height: 1.2em; }
+        #delete-shape-btn { display: flex; align-items: center; gap: 6px; margin-right: auto; }
+        #delete-shape-btn svg { width: 16px; height: 16px; }
 
         /* Global "Add Object" CTA */
         #add-object-btn {
@@ -211,19 +213,27 @@
         /* Editor resize affordances */
         .resize-handle {
             position: absolute;
-            width: 15px;
-            height: 15px;
+            width: 18px;
+            height: 18px;
             z-index: 1001;
-             background-image: repeating-linear-gradient(
-                -45deg,
-                transparent,
-                transparent 4px,
-                rgba(255, 255, 255, 0.5) 4px,
-                rgba(255, 255, 255, 0.5) 5px
-            );
+            pointer-events: auto;
+            transition: filter 0.2s ease;
         }
-        #resize-handle-bl { bottom: 5px; left: 5px; cursor: nesw-resize; }
-        #resize-handle-br { bottom: 5px; right: 5px; cursor: nwse-resize; }
+        #resize-handle-bl {
+            bottom: 5px;
+            left: 5px;
+            cursor: nesw-resize;
+            background: linear-gradient(225deg, transparent 50%, rgba(255, 255, 255, 0.75) 50%);
+        }
+        #resize-handle-br {
+            bottom: 5px;
+            right: 5px;
+            cursor: nwse-resize;
+            background: linear-gradient(135deg, transparent 50%, rgba(255, 255, 255, 0.75) 50%);
+        }
+        #resize-handle-bl:hover, #resize-handle-br:hover {
+            filter: brightness(1.25);
+        }
 
         /* Minimal close icon (kept simple for readability & CRT feel) */
         #close-btn { position: absolute; top: 5px; right: 5px; width: 20px; height: 20px; cursor: pointer; opacity: 0.8; transition: opacity 0.2s; }
@@ -231,6 +241,11 @@
         #close-btn::before, #close-btn::after { content: ''; position: absolute; top: 9px; left: 2px; width: 16px; height: 2px; background-color: #fff; }
         #close-btn::before { transform: rotate(45deg); }
         #close-btn::after { transform: rotate(-45deg); }
+        #shape-close-btn { position: absolute; top: 8px; right: 10px; width: 18px; height: 18px; cursor: pointer; opacity: 0.75; transition: opacity 0.2s; }
+        #shape-close-btn:hover { opacity: 1; }
+        #shape-close-btn::before, #shape-close-btn::after { content: ''; position: absolute; top: 8px; left: 2px; width: 14px; height: 2px; background-color: #fff; }
+        #shape-close-btn::before { transform: rotate(45deg); }
+        #shape-close-btn::after { transform: rotate(-45deg); }
 
         /* ===============================
            On-object UI card (CSS2D label)
@@ -259,7 +274,8 @@
         .notes-list li { padding: 5px; cursor: pointer; border-bottom: 1px solid rgba(255,255,255,0.2); }
         .notes-list li:hover { background: rgba(255,255,255,0.2); }
         .notes-list li:last-child { border-bottom: none; }
-        .add-note-btn { background: rgba(255,255,255,0.2); border: none; color: white; width: 100%; padding: 5px; margin-top: 5px; cursor: pointer; }
+        .add-note-btn { background: rgba(255,255,255,0.2); border: none; color: white; width: 100%; padding: 5px; margin-top: 5px; cursor: pointer; transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease; }
+        .add-note-btn:hover, .add-note-btn:focus { background: rgba(255,255,255,0.35); transform: translateY(-1px); box-shadow: 0 0 6px rgba(255,255,255,0.25); outline: 2px solid rgba(255,255,255,0.7); outline-offset: 2px; }
 
         /* Shape edit panel (object properties) */
         #shape-edit-panel {
@@ -371,6 +387,7 @@
     </div>
     <!-- Edit currently selected object's shape, name, and color -->
     <div id="shape-edit-panel">
+        <div id="shape-close-btn" title="Cancel"></div>
         <h3>Edit Shape</h3>
         <div class="form-group">
             <label for="shape-name-input">Name</label>
@@ -390,9 +407,15 @@
             <input type="color" id="shape-color-input" value="#ffffff">
         </div>
         <div class="button-group">
+            <button id="delete-shape-btn" class="btn" title="Delete Object">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                    <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                    <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3V2h11v1z"/>
+                </svg>
+                Delete
+            </button>
             <button id="save-shape-btn" class="btn">Save</button>
-            <button id="delete-shape-btn" class="btn" title="Delete Object">Delete</button>
-            <button id="close-shape-edit-btn" class="btn">Close</button>
+            <button id="close-shape-edit-btn" class="btn">Cancel</button>
         </div>
     </div>
 
@@ -466,6 +489,7 @@
         const resizeHandleBR = document.getElementById('resize-handle-br');
         const dragHandle = document.getElementById('drag-handle');
         const shapeEditPanel = document.getElementById('shape-edit-panel');
+        const shapeCloseBtn = document.getElementById('shape-close-btn');
         let deleteAction = null;
         
         // =================================================================================
@@ -726,8 +750,10 @@
             closeBtn.addEventListener('click', closeNoteEditorWithAnimation);
             modalConfirmBtn.addEventListener('click', () => { if (deleteAction) deleteAction(); });
             modalCancelBtn.addEventListener('click', hideModal);
+            const closeShapeEdit = () => { shapeEditPanel.style.display = 'none'; editingObject = null; };
             document.getElementById('save-shape-btn').addEventListener('click', saveShapeChanges);
-            document.getElementById('close-shape-edit-btn').addEventListener('click', () => { shapeEditPanel.style.display = 'none'; editingObject = null; });
+            document.getElementById('close-shape-edit-btn').addEventListener('click', closeShapeEdit);
+            shapeCloseBtn.addEventListener('click', closeShapeEdit);
             document.getElementById('delete-shape-btn').addEventListener('click', handleDeleteObjectFromShapeEditor);
 
             // Draggable + resizable editor


### PR DESCRIPTION
## Summary
- add a shared name entry modal with styling to collect titles before object or note creation
- enforce non-empty names with sequential defaults when saving new shapes or notes
- allow canceling creation without persisting changes while preserving the previous typing state

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e30160f2e8832caf114ac0d70a9cd4
